### PR TITLE
Improve responsive layout with mobile navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,26 @@
 import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { FiMenu, FiX } from 'react-icons/fi';
 
 export default function Header() {
+  const [open, setOpen] = useState(false);
   return (
-    <header className="fixed backdrop-blur top-0 h-20 w-full z-50 flex gap-20 justify-between items-center py-4 px-10 border-b border-gray-200">
-        <a href="/" className="logo text-2xl fira-code-bold">ANDESCODE</a>
-        <nav className="hidden md:flex gap-14 text-sm">
-          <Link to="/servicios" className="nav-link">Servicios</Link>
-          <Link to="/nosotros" className="nav-link">Nosotros</Link>
-          <Link to="/trabajos" className="nav-link">Trabajos</Link>
-          <Link to="/contacto" className="nav-link">Contacto</Link>
-        </nav>
-        <Link to="/contacto" className={`inline-block bg-[#191919] text-white dark:bg-white dark:text-[#191919] fira-code-medium px-4 py-2 border border-ink rounded-md transition hover:scale-105 transform duration-200 ease-in-out`}>
-        Agendá una reunión
+    <header className="fixed backdrop-blur top-0 h-20 w-full z-50 flex justify-between items-center py-4 px-6 md:px-10 border-b border-gray-200">
+      <a href="/" className="logo text-2xl fira-code-bold">ANDESCODE</a>
+      <nav className={`absolute top-20 left-0 w-full bg-white dark:bg-[#191919] flex-col items-center gap-6 py-6 md:py-0 md:static md:w-auto md:bg-transparent md:flex md:flex-row md:gap-14 text-sm ${open ? 'flex' : 'hidden'}`}>
+        <Link to="/servicios" className="nav-link" onClick={() => setOpen(false)}>Servicios</Link>
+        <Link to="/nosotros" className="nav-link" onClick={() => setOpen(false)}>Nosotros</Link>
+        <Link to="/trabajos" className="nav-link" onClick={() => setOpen(false)}>Trabajos</Link>
+        <Link to="/contacto" className="nav-link" onClick={() => setOpen(false)}>Contacto</Link>
+      </nav>
+      <div className="flex items-center gap-4">
+        <Link to="/contacto" className="hidden md:inline-block bg-[#191919] text-white dark:bg-white dark:text-[#191919] fira-code-medium px-4 py-2 border border-ink rounded-md transition hover:scale-105 transform duration-200 ease-in-out">
+          Agendá una reunión
         </Link>
+        <button className="md:hidden text-2xl" onClick={() => setOpen(!open)}>
+          {open ? <FiX /> : <FiMenu />}
+        </button>
+      </div>
     </header>
   );
 }

--- a/src/sections/NosotrosHero.tsx
+++ b/src/sections/NosotrosHero.tsx
@@ -38,9 +38,9 @@ export default function NosotrosHero() {
       </section>
 
       {/* Valores que nos diferencian */}
-      <section className="py-10">
-        <h2 className="fira-code-semibold text-3xl font-semibold mb-10 dark:text-white">Valores que nos diferencian</h2>
-        <div className="flex flex-wrap justify-center gap-40">
+        <section className="py-10">
+          <h2 className="fira-code-semibold text-3xl font-semibold mb-10 dark:text-white">Valores que nos diferencian</h2>
+          <div className="flex flex-wrap justify-center gap-10 md:gap-40">
             {valores.map((item, i) => (
               <div key={i} className="flex flex-col items-center w-40">
                 <div className="w-50 h-50 flex items-center justify-center mb-4">
@@ -78,25 +78,25 @@ export default function NosotrosHero() {
       </MouseParallaxCard>
 
       {/* Call to Action */}
-      <section className="grid grid-cols-2 py-16 px-30">
-        <h2 className="fira-code-medium text-xl md:text-2xl dark:text-white font-semibold mb-2 ml-10 text-left ">
-          ¿Querés saber si somos el equipo <br />
-          ideal para tu proyecto?
-        </h2>
+        <section className="grid grid-cols-1 md:grid-cols-2 py-16 px-6 md:px-30">
+          <h2 className="fira-code-medium text-xl md:text-2xl dark:text-white font-semibold mb-2 text-center md:text-left md:ml-10">
+            ¿Querés saber si somos el equipo <br />
+            ideal para tu proyecto?
+          </h2>
 
-        <div className="flex gap-4 justify-center items-start">
-          <Link to="/contacto" className="w-full md:w-64">
-            <button className="w-full dark-button bg-black text-white py-2 rounded max-h-[60px]">
-              Agendá una reunión
-            </button>
-          </Link>
-          <Link to="/trabajos" className="w-full md:w-64">
-            <button className="w-full border !border-black bg-white text-black dark:bg-[#191919] dark:text-white dark:!border-white  px-6 py-2 rounded hover:text-ink max-h-[60px]">
-              Conocé más sobre nosotros
-            </button>
-          </Link>
-        </div>
-      </section>
+          <div className="flex gap-4 justify-center items-start">
+            <Link to="/contacto" className="w-full md:w-64">
+              <button className="w-full dark-button bg-black text-white py-2 rounded max-h-[60px]">
+                Agendá una reunión
+              </button>
+            </Link>
+            <Link to="/trabajos" className="w-full md:w-64">
+              <button className="w-full border !border-black bg-white text-black dark:bg-[#191919] dark:text-white dark:!border-white px-6 py-2 rounded hover:text-ink max-h-[60px]">
+                Conocé más sobre nosotros
+              </button>
+            </Link>
+          </div>
+        </section>
 
     </main>
   );

--- a/src/sections/TrabajosHero.tsx
+++ b/src/sections/TrabajosHero.tsx
@@ -75,24 +75,24 @@ export default function NuestroTrabajo() {
       </section>
 
       {/* Cierre CTA */}
-      <section className="grid grid-cols-2 py-16 px-30">
-        <h2 className="fira-code-medium text-xl md:text-2xl font-semibold mb-2 ml-10 dark:text-white text-left">
-          El cambio comienza hoy.
-        </h2>
+        <section className="grid grid-cols-1 md:grid-cols-2 py-16 px-6 md:px-30">
+          <h2 className="fira-code-medium text-xl md:text-2xl font-semibold mb-2 text-center md:text-left md:ml-10 dark:text-white">
+            El cambio comienza hoy.
+          </h2>
 
-        <div className="flex gap-4 justify-center items-start">
-          <Link to="/contacto" className="w-full md:w-64">
-            <button className="w-full dark-button bg-black text-white py-2 rounded max-h-[60px]">
-              Agendá una reunión
-            </button>
-          </Link>
-          <Link to="/Nosotros" className="w-full md:w-64">
-            <button className="w-full border bg-white text-[#191919] !  border-black dark:bg-[#191919] dark:text-[#ffffff] dark:!border-[#ffffff] px-6 py-2 rounded hover:text-ink max-h-[60px]">
-              Conocé más sobre nosotros
-            </button>
-          </Link>
-        </div>
-      </section>
+          <div className="flex gap-4 justify-center items-start">
+            <Link to="/contacto" className="w-full md:w-64">
+              <button className="w-full dark-button bg-black text-white py-2 rounded max-h-[60px]">
+                Agendá una reunión
+              </button>
+            </Link>
+            <Link to="/Nosotros" className="w-full md:w-64">
+              <button className="w-full border bg-white text-[#191919] !  border-black dark:bg-[#191919] dark:text-[#ffffff] dark:!border-[#ffffff] px-6 py-2 rounded hover:text-ink max-h-[60px]">
+                Conocé más sobre nosotros
+              </button>
+            </Link>
+          </div>
+        </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add hamburger navigation for mobile header
- make Nosotros and Trabajos call-to-action sections stack on small screens
- adjust spacing in Nosotros values grid for smaller devices

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a462076748322ac91fffafe36abac