### PR TITLE
ci: GitHub Actions deploy workflow (build + rsync + smoke)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,78 @@
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 7
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          echo "${{ secrets.VPS_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Backup current release on VPS
+        run: |
+          ssh -i ~/.ssh/id_ed25519 \
+            "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" \
+            'sudo -n /usr/local/bin/andescode-backup.sh'
+
+      - name: Rsync dist to VPS
+        run: |
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/id_ed25519" \
+            dist/ \
+            "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/var/www/andescode/"
+
+  smoke:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: HTTP smoke checks
+        run: |
+          set -euo pipefail
+          for path in / /auditorias /sitemap.xml; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' "https://andescode.com.ar${path}")
+            echo "GET ${path} -> ${code}"
+            if [ "$code" != "200" ]; then
+              echo "::error::smoke check failed for ${path} (got ${code})"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary

Closes manual `npm run build && scp` flow. Adds `.github/workflows/deploy.yml` with three jobs:

- **build** — `npm ci` + `npm run build` + upload `dist/` artifact.
- **deploy** — `rsync -az --delete` over SSH key auth to `/var/www/andescode/`, server-side backup before rsync.
- **smoke** — `curl` to `/`, `/auditorias`, `/sitemap.xml`, fail on non-200.

Concurrency `deploy-prod` (`cancel-in-progress: false`) so two pushes do not race. Environment `production` enables optional manual approval gate later. `workflow_dispatch` allows manual redeploy.

## Why rsync instead of `appleboy/scp-action`

- One roundtrip with `--delete` (no stale files left in `/var/www`).
- Backup is owned by the VPS-side script (correct ownership of backup logic).
- Smaller blast radius — no third-party action with broad token access.

## Gate before merging to main

This PR depends on AND-17 (SSH-key auth + non-root deploy user). **Do not merge until the following secrets are configured in the repo (Settings → Secrets and variables → Actions):**

- `VPS_HOST` — VPS IP/hostname
- `VPS_USER` — `deploy` (non-root user created in AND-17)
- `VPS_SSH_KEY` — OpenSSH private key for the CI deploy keypair
- `VPS_KNOWN_HOSTS` — output of `ssh-keyscan -H <host>`

Server prerequisites from AND-17:

- `deploy` user owns `/var/www/andescode` (group `www-data`, mode `g+w`).
- `/usr/local/bin/andescode-backup.sh` exists, owned by root, executable by `deploy` via sudoers NOPASSWD scoped to that binary only.

## Test plan

- [ ] Configure the four secrets in GitHub.
- [ ] Trigger `workflow_dispatch` run before merging to verify build + deploy + smoke green against current `main`.
- [ ] Merge to main; confirm push trigger fires and prod stays green.

Refs AND-19, AND-17, AND-16.