### PR TITLE
ci(deploy): harden SSH key loading + fail fast on malformed key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,12 +41,24 @@ jobs:
           path: dist
 
       - name: Setup SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_KNOWN_HOSTS: ${{ secrets.VPS_KNOWN_HOSTS }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 700 ~/.ssh
+          # Strip CR (Windows line endings) and ensure trailing newline so
+          # openssl/libcrypto can parse the OpenSSH PEM block cleanly.
+          printf '%s\n' "$VPS_SSH_KEY" | tr -d '\r' > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          echo "${{ secrets.VPS_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          printf '%s\n' "$VPS_KNOWN_HOSTS" | tr -d '\r' > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
+          # Fail fast with a clear message if the key is malformed.
+          if ! ssh-keygen -y -f ~/.ssh/id_ed25519 > /dev/null 2>&1; then
+            echo "::error::VPS_SSH_KEY secret is not a valid OpenSSH private key."
+            echo "Expected -----BEGIN OPENSSH PRIVATE KEY----- block. Re-upload from 'cat id_ed25519' output."
+            exit 1
+          fi
 
       - name: Backup current release on VPS
         run: |


### PR DESCRIPTION
## Why

First deploy run on `main` (run 27243732138) failed at *Backup current release on VPS* with `error in libcrypto` → ssh could not parse `~/.ssh/id_ed25519`. Two common causes: the secret lost internal newlines through YAML interpolation, or it has CRLF line endings from a Windows-edited paste.

## Fix

In the *Setup SSH* step of `.github/workflows/deploy.yml`:

- Pass `VPS_SSH_KEY` and `VPS_KNOWN_HOSTS` via `env:` instead of inline `${{ secrets.X }}` in the shell string, so multi-line secrets survive intact.
- Use `printf '%s\n' | tr -d '\r'` to force LF-only with a trailing newline.
- Validate with `ssh-keygen -y -f` before any ssh/rsync; emit a clear `::error::` annotation if the secret is malformed.

## Test plan

- [x] YAML syntax validates.
- [ ] Merge → first run goes past *Setup SSH*.
- [ ] If the key itself is wrong, the validation step now fails with an actionable message instead of `error in libcrypto` from inside ssh.

Refs AND-19.