### PR TITLE
ci(deploy): safe SSH key diagnostics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,12 +53,41 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           printf '%s\n' "$VPS_KNOWN_HOSTS" | tr -d '\r' > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
-          # Fail fast with a clear message if the key is malformed.
+          # Safe diagnostics: report metadata about the secret content without
+          # printing the content itself (GH Actions masks the secret value, but
+          # we still avoid echoing it). This is enough to tell the operator
+          # exactly what they pasted wrong.
+          bytes=$(wc -c < ~/.ssh/id_ed25519 | tr -d ' ')
+          lines=$(wc -l < ~/.ssh/id_ed25519 | tr -d ' ')
+          has_cr=$(grep -c $'\r' ~/.ssh/id_ed25519 || true)
+          first_line_kind="unknown"
+          last_line_kind="unknown"
+          if head -1 ~/.ssh/id_ed25519 | grep -q '^-----BEGIN OPENSSH PRIVATE KEY-----$'; then
+            first_line_kind="openssh-private-header"
+          elif head -1 ~/.ssh/id_ed25519 | grep -qE '^-----BEGIN (RSA|EC|DSA|ENCRYPTED) PRIVATE KEY-----$'; then
+            first_line_kind="legacy-pem-header"
+          elif head -1 ~/.ssh/id_ed25519 | grep -qE '^(ssh-ed25519|ssh-rsa|ecdsa-sha2-)'; then
+            first_line_kind="PUBLIC-KEY (user pasted .pub instead of private)"
+          elif head -1 ~/.ssh/id_ed25519 | grep -q '^PuTTY-User-Key-File'; then
+            first_line_kind="putty-ppk (need openssh, run: puttygen file.ppk -O private-openssh -o id_ed25519)"
+          fi
+          if tail -n 1 ~/.ssh/id_ed25519 | grep -q '^-----END OPENSSH PRIVATE KEY-----$'; then
+            last_line_kind="openssh-private-footer"
+          fi
+          echo "::group::SSH key secret diagnostics"
+          echo "bytes:          $bytes"
+          echo "lines:          $lines"
+          echo "CR characters:  $has_cr"
+          echo "first line:     $first_line_kind"
+          echo "last  line:     $last_line_kind"
+          echo "::endgroup::"
+
           if ! ssh-keygen -y -f ~/.ssh/id_ed25519 > /dev/null 2>&1; then
-            echo "::error::VPS_SSH_KEY secret is not a valid OpenSSH private key."
-            echo "Expected -----BEGIN OPENSSH PRIVATE KEY----- block. Re-upload from 'cat id_ed25519' output."
+            echo "::error::VPS_SSH_KEY is not a valid OpenSSH private key (see diagnostics above)."
+            echo "::error::Fix: re-upload the content of '~/.ssh/andescode-ci' (the file WITHOUT .pub). It must start with '-----BEGIN OPENSSH PRIVATE KEY-----' and end with '-----END OPENSSH PRIVATE KEY-----'."
             exit 1
           fi
+          echo "VPS_SSH_KEY parsed OK as OpenSSH private key."
 
       - name: Backup current release on VPS
         run: |


### PR DESCRIPTION
Adds metadata-only diagnostics in Setup SSH so the operator can tell exactly what they pasted into VPS_SSH_KEY without leaking the content. Needed because the re-uploaded key still fails libcrypto parse. Refs AND-19.